### PR TITLE
Fix gRPC user agent/invocation streaming, add climate sensors, instant optimistic UI updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Polestar API Live Test Credentials
+# Copy this file to .env and fill in your actual credentials
+
+# Your Polestar ID email address
+POLESTAR_EMAIL=your_email@example.com
+
+# Your Polestar ID password
+# Note: If your password contains special characters, wrap in quotes
+# Examples:
+#   POLESTAR_PASSWORD='my\!password'
+#   POLESTAR_PASSWORD="mypassword123"
+POLESTAR_PASSWORD=your_password_here
+
+# Enable write command tests (DANGEROUS - prompts before each command)
+# Set to 1 to enable tests that send commands to your car
+# POLESTAR_ENABLE_WRITE_TESTS=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+Project-specific guidance for the `unofficial-polestar-api` repo. The general
+behavioral guidelines live in `~/.claude/CLAUDE.md` — do not duplicate them
+here.
+
+## What this repo is
+
+Async Python client for Polestar's gRPC cloud APIs (C3 / Volvo Cars Cloud
+Connectivity backend) plus a Home Assistant custom integration that consumes it.
+Reverse-engineered from the official mobile app — APIs are undocumented and may
+break.
+
+## Layout
+
+- `src/polestar_api/` — library (packaged as `polestar_api` on PyPI)
+  - `client.py` — `PolestarApi` entry point (async context manager)
+  - `auth.py` — OIDC/PKCE + token refresh, pluggable `TokenStore`
+  - `connection.py` — `GrpcConnection` (grpclib `Channel` + bearer injection)
+  - `discovery.py` — C3 endpoint + app-backend GraphQL vehicle list
+  - `grpc.py` — `unary_unary` / `unary_stream` raw-bytes helpers with retry
+  - `wire.py` + `codec.py` — hand-rolled protobuf (no `.proto`, no protoc)
+  - `backend.py` — `BackendProfile` (C3 default, PCCS variant)
+  - `vehicle.py` — `Vehicle` facade with ~50 high-level methods
+  - `models/` — frozen dataclasses using `ProtoMessage` mixin + `IntEnum`s
+  - `services/` — one client per gRPC service
+- `custom_components/polestar/` — HACS-distributed HA integration
+  - `__init__.py`, `config_flow.py`, `coordinator.py` (DataUpdateCoordinator)
+  - `services.py` + `services.yaml` — HA service registrations
+  - `token_store.py` — HA-backed `TokenStore` implementation
+  - `demo.py` — fake vehicle for demo mode
+  - Platforms: `sensor`, `binary_sensor`, `lock`, `switch`, `button`, `number`,
+    `select`, `time`, `calendar`, `update`, `device_tracker`
+- `tests/` — pytest + pytest-asyncio (`asyncio_mode = "auto"`)
+- `docs/` — mkdocs + mkdocstrings reference
+
+## Conventions
+
+- **Python ≥ 3.12**, `from __future__ import annotations` everywhere.
+- **frozen dataclasses** for all protobuf message types. Mutating state goes
+  through `dataclasses.replace(...)` (see `coordinator.py`).
+- **No protoc**. Protobuf schemas live in the `schema={field_num: name, ...}`
+  class arg of `ProtoMessage` subclasses. Wire types are inferred from type
+  hints in `wire._infer_wire_type`. If you add a new field type, update that
+  function.
+- **`IntEnum` for enums**, value `0` is `UNSPECIFIED` (matches proto3 default).
+- **Service path strings** live in `backend.py`, never hard-coded in services.
+  Services resolve them via `self._connection.backend.<x>_svc`.
+- **Service methods** take a `VehicleRequest(vin=...)` envelope by default and
+  return parsed dataclasses. Errors propagate as `ApiError` / `GRPCError`.
+- **Streaming endpoints** retry only when no data has been yielded yet
+  (subscription semantics). See `grpc.unary_stream`.
+- **HA integration must not block the event loop.** `ssl.create_default_context()`
+  and `_HTTPX_SSL_CONTEXT` are built at import time for exactly this reason —
+  preserve that pattern.
+- **gRPC user agent is faked** (`grpc-java-okhttp/1.68.2`) in `connection.py` —
+  the C3 server rejects other UAs with `UNIMPLEMENTED`. Do not change.
+- **No comments in code** unless the surrounding code has explanatory ones;
+  match the local style.
+
+## Testing
+
+- `uv run pytest` (or `pytest` inside a `.venv` with the dev extras).
+- Tests use `pytest-asyncio` with `asyncio_mode = "auto"` — no `@pytest.mark.asyncio` decorator needed.
+- `tests/conftest.py` provides mock fixtures for OIDC config, token responses,
+  and vehicle list responses.
+- There is no live API integration test — don't add one without explicit
+  approval, it would require real Polestar credentials.
+
+## CI
+
+GitHub Actions workflows in `.github/workflows/`:
+- `validate.yml` — HACS action validates the custom component.
+- `hassfest.yml` — HA manifest validation.
+- `docs.yml` — builds mkdocs site.
+- `release-ha-ha.yml` — HA release automation.
+
+## Common pitfalls
+
+- **Do not add `protoc` or generated stubs.** The whole point of
+  `wire.py` / `codec.py` is avoiding a codegen step.
+- **Do not change gRPC user agent** in `connection.py` — C3 rejects it.
+- **Do not introduce sync I/O** in the HA integration paths
+  (`__init__.py`, `coordinator.py`, `entity.py`).
+- **Do not break the public `polestar_api` API** without a deprecation note
+  in the changelog; the HA integration imports it directly.
+- **TLS / `keepalive` settings** in `connection.py` match the Android app's
+  OkHttp channel — changing them has caused `UNAVAILABLE` errors before.
+- **APIs are undocumented and may break without notice.** When adding a new
+  endpoint, mark per-model availability (P2 vs P4) in docstrings, mirroring
+  the existing entries in `vehicle.py`.
+
+## Reference
+
+- Full library docs: https://kildahldev.github.io/unofficial-polestar-api/
+- HA install / entities: `ha_integration_README.md`
+- Dashboard card examples: `example-dashboard-cards.md`

--- a/README.md
+++ b/README.md
@@ -54,15 +54,51 @@ See the [HA integration README](ha_integration_README.md) for setup, entities, s
 - **Honk & flash** — flash lights or honk+flash
 - **Windows** — open/close all windows
 - **Exterior** — door, window, sunroof, hood, tailgate, and alarm status.
-- **Charging** — target SOC, amp limit, charge timers, start/stop immediate charging *(amp limit appears to be unavailable on Polestar 4)*
+- **Charging** — target SOC, amp limit, charge timers, start/stop immediate charging
 - **Charge locations** — full CRUD for saved locations with per-location amp limits, min SOC, timers, departure times, and smart charging
-- **Health** — service warnings, fluid levels, tyre pressures (kPa), all exterior light warnings, 12V battery *(Tyre pressure is unavailable on Polestar 2 as it does not have TPMS)*
+- **Health** — service warnings, fluid levels, tyre pressures (kPa), all exterior light warnings, 12V battery
 - **Availability** — vehicle online status with unavailable reason
 - **Weather** — temperature at car location
-- **OTA** — software update info, scheduling, install now, cancel *(Appears to be unavailable on Polestar 4)*
-- **Pre-cleaning** — air quality status (PM2.5, AQI) and start/stop cabin pre-cleaning *(Appears to be unavailable on Polestar 4)*
+- **OTA** — software update info, scheduling, install now, cancel
+- **Pre-cleaning** — air quality status (PM2.5, AQI) and start/stop cabin pre-cleaning
 
 For the full API reference with all methods, models, and enums, see the [docs](https://kildahldev.github.io/unofficial-polestar-api/).
+
+### Feature availability by model
+
+Not all features are available on all models. Unsupported commands are
+detected at runtime — the corresponding HA entities become unavailable
+automatically and re-enable if a future software update adds support.
+
+| Feature | Polestar 2 | Polestar 3 | Polestar 4 |
+|---------|:----------:|:----------:|:----------:|
+| Battery | ✅ | ✅ | ✅ |
+| Location / parked location | ✅ | ✅ | ✅ |
+| Climate (start/stop/temp/seats) | ✅ | ✅ | ✅ |
+| Climate timers (list) | ✅ | ✅ | ✅ |
+| Climate timer settings | ✅ | ✅ | ❌ |
+| Lock / unlock | ✅ | ✅ | ✅ |
+| Trunk unlock | ✅ | ✅ | ✅ |
+| Honk & flash | ✅ | ✅ | ✅ |
+| Windows open/close | ✅ | ✅ | ❌ |
+| Exterior status | ✅ | ✅ | ✅ |
+| Charging start/stop | ✅ | ✅ | ✅ |
+| Target SOC | ✅ | ✅ | ✅ |
+| Amp limit | ✅ | ✅ | ❌ |
+| Charge timer | ✅ | ✅ | ✅ |
+| Charge locations | ✅ | ✅ | ✅ |
+| Health (tyre pressures) | ❌ (no TPMS) | ✅ | ✅ |
+| Availability | ✅ | ✅ | ✅ |
+| Weather | ✅ | ✅ | ✅ |
+| OTA software info | ✅ | ✅ | ✅ |
+| OTA schedule / install / cancel | ✅ | ✅ | ❓ |
+| Pre-cleaning | ✅ | ✅ | ✅ |
+| Dashboard (legacy PCCS) | ✅ | ❌ | ❌ |
+| Connectivity (legacy PCCS) | ✅ | ❌ | ❌ |
+
+> **Note:** Availability was tested on a Polestar 4 (software version as of Jul 2026).
+> Polestar 2 and 3 columns are based on community reports and may vary by
+> software version. Please report back what works and what doesn't for your model.
 
 ## FAQ
 

--- a/custom_components/polestar/button.py
+++ b/custom_components/polestar/button.py
@@ -22,6 +22,7 @@ class PolestarButtonDescription(ButtonEntityDescription):
     """Button description with press callable."""
 
     press_fn: Callable[[PolestarButton], Awaitable[Any]]
+    capability: str | None = None
 
 
 BUTTONS: tuple[PolestarButtonDescription, ...] = (
@@ -32,7 +33,9 @@ BUTTONS: tuple[PolestarButtonDescription, ...] = (
         press_fn=lambda button: button.coordinator.async_run_command(
             lambda: button._vehicle.honk_flash(action=HonkFlashAction.FLASH),
             error_message="Flash lights command failed",
+            capability="flash",
         ),
+        capability="flash",
     ),
     PolestarButtonDescription(
         key="honk",
@@ -41,7 +44,9 @@ BUTTONS: tuple[PolestarButtonDescription, ...] = (
         press_fn=lambda button: button.coordinator.async_run_command(
             lambda: button._vehicle.honk_flash(action=HonkFlashAction.HONK),
             error_message="Honk command failed",
+            capability="honk",
         ),
+        capability="honk",
     ),
     PolestarButtonDescription(
         key="honk_flash",
@@ -50,7 +55,9 @@ BUTTONS: tuple[PolestarButtonDescription, ...] = (
         press_fn=lambda button: button.coordinator.async_run_command(
             lambda: button._vehicle.honk_flash(action=HonkFlashAction.HONK_AND_FLASH),
             error_message="Honk and flash command failed",
+            capability="honk_flash",
         ),
+        capability="honk_flash",
     ),
     PolestarButtonDescription(
         key="wakeup",
@@ -63,18 +70,21 @@ BUTTONS: tuple[PolestarButtonDescription, ...] = (
         name="Open windows",
         icon="mdi:window-open",
         press_fn=lambda button: button.coordinator.async_open_windows(),
+        capability="open_windows",
     ),
     PolestarButtonDescription(
         key="close_windows",
         name="Close windows",
         icon="mdi:window-closed",
         press_fn=lambda button: button.coordinator.async_close_windows(),
+        capability="close_windows",
     ),
     PolestarButtonDescription(
         key="unlock_trunk",
         name="Unlock trunk",
         icon="mdi:car-back",
         press_fn=lambda button: button.coordinator.async_unlock_trunk(),
+        capability="unlock_trunk",
     ),
 )
 
@@ -102,6 +112,14 @@ class PolestarButton(PolestarEntity, ButtonEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{self._vehicle.vin}_{description.key}"
+
+    @property
+    def available(self) -> bool:
+        """Return False if the car doesn't support this command."""
+        cap = self.entity_description.capability
+        if cap and not self.coordinator.is_command_supported(cap):
+            return False
+        return super().available
 
     async def async_press(self) -> None:
         await self.entity_description.press_fn(self)

--- a/custom_components/polestar/coordinator.py
+++ b/custom_components/polestar/coordinator.py
@@ -156,6 +156,7 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
         self._installed_version_cache: str | None = None
         self._stream_tasks: dict[str, asyncio.Task[None]] = {}
         self._unsupported_streams: set[str] = set()
+        self._unsupported_commands: set[str] = set()
 
     @staticmethod
     def _command_succeeded(response: Any) -> bool:
@@ -205,15 +206,29 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
         *,
         error_message: str = "Command failed",
         timeout: int = 30,
+        capability: str | None = None,
     ) -> Any:
-        """Run a remote command and validate its response."""
+        """Run a remote command and validate its response.
+
+        If *capability* is set and the server returns FAILED_PRECONDITION or
+        UNIMPLEMENTED, the capability is marked as unsupported so entities can
+        become unavailable instead of repeatedly failing.
+        """
         try:
             response = await asyncio.wait_for(command(), timeout=timeout)
         except TimeoutError:
             raise HomeAssistantError(f"{error_message} (timed out after {timeout}s)")
+        except GRPCError as err:
+            if capability and err.status in (GrpcStatus.UNIMPLEMENTED, GrpcStatus.FAILED_PRECONDITION):
+                self._unsupported_commands.add(capability)
+            raise HomeAssistantError(self._command_error_message(err, error_message))
         if not self._command_succeeded(response):
             raise HomeAssistantError(self._command_error_message(response, error_message))
         return response
+
+    def is_command_supported(self, capability: str) -> bool:
+        """Return whether a command capability is supported by the car."""
+        return capability not in self._unsupported_commands
 
     def _schedule_background_refresh(self, *attrs: str) -> None:
         """Kick off a background refresh for the given attributes."""
@@ -286,6 +301,7 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
 
         data = PolestarVehicleData(**values)
         self._update_installed_version_cache(data.software)
+        self._unsupported_commands.clear()
         self._restart_dead_streams()
         return data
 
@@ -526,6 +542,7 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
         await self.async_run_command(
             self.vehicle.start_precleaning,
             error_message="Start pre-cleaning command failed",
+            capability="precleaning",
         )
         self._schedule_background_refresh("precleaning")
 
@@ -534,6 +551,7 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
         await self.async_run_command(
             self.vehicle.stop_precleaning,
             error_message="Stop pre-cleaning command failed",
+            capability="precleaning",
         )
         self._schedule_background_refresh("precleaning")
 
@@ -542,6 +560,7 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
         response = await self.async_run_command(
             self.vehicle.start_charging,
             error_message="Start charging command failed",
+            capability="charging",
         )
         self._schedule_background_refresh("battery")
         return response
@@ -551,6 +570,7 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
         response = await self.async_run_command(
             self.vehicle.stop_charging,
             error_message="Stop charging command failed",
+            capability="charging",
         )
         self._schedule_background_refresh("battery")
         return response
@@ -560,6 +580,7 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
         response = await self.async_run_command(
             self.vehicle.open_windows,
             error_message="Open windows command failed",
+            capability="open_windows",
         )
         self._schedule_background_refresh("exterior")
         return response
@@ -569,6 +590,7 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
         response = await self.async_run_command(
             self.vehicle.close_windows,
             error_message="Close windows command failed",
+            capability="close_windows",
         )
         self._schedule_background_refresh("exterior")
         return response
@@ -578,6 +600,7 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
         response = await self.async_run_command(
             self.vehicle.unlock_trunk,
             error_message="Unlock trunk command failed",
+            capability="unlock_trunk",
         )
         self._schedule_background_refresh("exterior")
         return response

--- a/custom_components/polestar/coordinator.py
+++ b/custom_components/polestar/coordinator.py
@@ -149,11 +149,13 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
                 seconds=entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
             ),
             config_entry=entry,
+            always_update=True,
         )
         self.vehicle = vehicle
         self.climate_preferences = ClimateCommandPreferences()
         self._installed_version_cache: str | None = None
         self._stream_tasks: dict[str, asyncio.Task[None]] = {}
+        self._unsupported_streams: set[str] = set()
 
     @staticmethod
     def _command_succeeded(response: Any) -> bool:
@@ -284,6 +286,7 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
 
         data = PolestarVehicleData(**values)
         self._update_installed_version_cache(data.software)
+        self._restart_dead_streams()
         return data
 
     async def async_request_attrs_refresh(self, *attrs: str) -> None:
@@ -302,26 +305,43 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
             self._update_installed_version_cache(data.software)
         self.async_set_updated_data(data)
 
+    _STREAMS: dict[str, str] = {
+        "battery": "stream_battery",
+        "location": "stream_location",
+        "parked_location": "stream_parked_location",
+        "climate": "stream_climate",
+        "exterior": "stream_exterior",
+        "precleaning": "stream_precleaning",
+        "odometer": "stream_odometer",
+    }
+
     async def async_start_streams(self) -> None:
         """Start background stream tasks for live battery/location/exterior/climate updates."""
         if self._stream_tasks:
             return
-
-        streams = {
-            "battery": "stream_battery",
-            "location": "stream_location",
-            "climate": "stream_climate",
-            "exterior": "stream_exterior",
-            "precleaning": "stream_precleaning",
-            "odometer": "stream_odometer",
-        }
-        for attr, method_name in streams.items():
+        for attr, method_name in self._STREAMS.items():
             method = getattr(self.vehicle, method_name, None)
             if method is not None:
                 self._stream_tasks[attr] = asyncio.create_task(
                     self._async_run_stream(attr, method),
                     name=f"polestar-{self.vehicle.vin}-{attr}-stream",
                 )
+
+    def _restart_dead_streams(self) -> None:
+        """Restart streams that gave up, after a successful poll proves connectivity."""
+        for attr, method_name in self._STREAMS.items():
+            if attr in self._unsupported_streams:
+                continue
+            task = self._stream_tasks.get(attr)
+            if task is not None and not task.done():
+                continue
+            method = getattr(self.vehicle, method_name, None)
+            if method is None:
+                continue
+            self._stream_tasks[attr] = asyncio.create_task(
+                self._async_run_stream(attr, method),
+                name=f"polestar-{self.vehicle.vin}-{attr}-stream",
+            )
 
     async def async_shutdown(self) -> None:
         """Cancel any running stream tasks."""
@@ -330,6 +350,7 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
         if self._stream_tasks:
             await asyncio.gather(*self._stream_tasks.values(), return_exceptions=True)
         self._stream_tasks.clear()
+        self._unsupported_streams.clear()
 
     async def _async_run_stream(
         self,
@@ -353,6 +374,7 @@ class PolestarCoordinator(DataUpdateCoordinator[PolestarVehicleData]):
             except GRPCError as err:
                 if err.status == GrpcStatus.UNIMPLEMENTED:
                     _LOGGER.debug("Live %s stream not supported for %s, stopping", attr, self.vehicle.vin)
+                    self._unsupported_streams.add(attr)
                     return
                 consecutive_failures += 1
                 delay = self._stream_retry_delay(attr, consecutive_failures, err)

--- a/custom_components/polestar/entity.py
+++ b/custom_components/polestar/entity.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import time
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -12,6 +13,41 @@ from .coordinator import PolestarCoordinator
 
 if TYPE_CHECKING:
     from polestar_api.vehicle import Vehicle
+
+
+class OptimisticStateMixin:
+    """Show a locally-set value instantly, ahead of the next confirmed refresh.
+
+    The Polestar cloud backend can take several seconds to reflect a command.
+    Call `_set_optimistic(value)` right after a command succeeds to display
+    the new value immediately, and read state through `_resolve_optimistic`
+    instead of the raw coordinator value. The override is dropped as soon as
+    the coordinator reports a matching value, or after `_OPTIMISTIC_TTL`
+    seconds if the backend never confirms it.
+    """
+
+    _OPTIMISTIC_TTL = 10.0
+    _optimistic_value: Any = None
+    _optimistic_deadline: float = 0.0
+
+    def _set_optimistic(self, value: Any) -> None:
+        self._optimistic_value = value
+        self._optimistic_deadline = time.monotonic() + self._OPTIMISTIC_TTL
+        self.async_write_ha_state()
+
+    def _clear_optimistic(self) -> None:
+        self._optimistic_value = None
+        self._optimistic_deadline = 0.0
+        self.async_write_ha_state()
+
+    def _resolve_optimistic(self, real_value: Any) -> Any:
+        if self._optimistic_deadline == 0.0:
+            return real_value
+        if real_value == self._optimistic_value or time.monotonic() >= self._optimistic_deadline:
+            self._optimistic_deadline = 0.0
+            self._optimistic_value = None
+            return real_value
+        return self._optimistic_value
 
 
 class PolestarEntity(CoordinatorEntity[PolestarCoordinator]):

--- a/custom_components/polestar/lock.py
+++ b/custom_components/polestar/lock.py
@@ -51,6 +51,7 @@ class PolestarLock(PolestarEntity, LockEntity):
             await self.coordinator.async_run_command(
                 self._vehicle.lock,
                 error_message="Lock command failed",
+                capability="lock",
             )
         finally:
             self._attr_is_locking = False
@@ -66,6 +67,7 @@ class PolestarLock(PolestarEntity, LockEntity):
             await self.coordinator.async_run_command(
                 self._vehicle.unlock,
                 error_message="Unlock command failed",
+                capability="unlock",
             )
         finally:
             self._attr_is_unlocking = False

--- a/custom_components/polestar/manifest.json
+++ b/custom_components/polestar/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": ["http"],
   "documentation": "https://github.com/kildahldev/unofficial-polestar-api/blob/main/ha_integration_README.md",
   "integration_type": "device",
-  "iot_class": "cloud_polling",
+  "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/kildahldev/unofficial-polestar-api/issues",
   "requirements": ["unofficial-polestar-api==0.3.0"],
   "version": "0.3.0"

--- a/custom_components/polestar/number.py
+++ b/custom_components/polestar/number.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .coordinator import PolestarCoordinator, PolestarVehicleData
-from .entity import PolestarEntity
+from .entity import OptimisticStateMixin, PolestarEntity
 from polestar_api.models.charging import ChargeTargetLevelSettingType
 from polestar_api.models.parking_climate_timer import ParkingClimateTimerSettings
 
@@ -89,7 +89,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class PolestarNumber(PolestarEntity, RestoreEntity, NumberEntity):
+class PolestarNumber(OptimisticStateMixin, PolestarEntity, RestoreEntity, NumberEntity):
     """Polestar number entity."""
 
     entity_description: PolestarNumberDescription
@@ -130,22 +130,28 @@ class PolestarNumber(PolestarEntity, RestoreEntity, NumberEntity):
     @property
     def native_value(self) -> float | None:
         try:
-            return self.entity_description.value_fn(self.coordinator)
+            real_value = self.entity_description.value_fn(self.coordinator)
         except (AttributeError, TypeError):
             return None
+        return self._resolve_optimistic(real_value)
 
     async def async_set_native_value(self, value: float) -> None:
         if self.entity_description.key == "climate_target_temperature":
             self.coordinator.climate_preferences.target_temperature = value
-            self.async_write_ha_state()
+            self._set_optimistic(value)
             return
 
+        self._set_optimistic(value)
         result = self.entity_description.set_fn(self.coordinator, value)
         if result is not None:
-            await result
+            try:
+                await result
+            except Exception:
+                self._clear_optimistic()
+                raise
 
 
-class PolestarTimerTemperatureNumber(PolestarEntity, NumberEntity):
+class PolestarTimerTemperatureNumber(OptimisticStateMixin, PolestarEntity, NumberEntity):
     """API-backed number entity for parking climate timer target temperature."""
 
     _attr_name = "Timer target temperature"
@@ -176,11 +182,16 @@ class PolestarTimerTemperatureNumber(PolestarEntity, NumberEntity):
         settings = self._settings
         if settings is None:
             return None
-        return settings.temperature_celsius
+        return self._resolve_optimistic(settings.temperature_celsius)
 
     async def async_set_native_value(self, value: float) -> None:
         settings = self._settings
         if settings is None:
             return
         updated = replace(settings, temperature_celsius=value, is_temperature_requested=True)
-        await self.coordinator.async_set_climate_timer_settings(updated)
+        self._set_optimistic(value)
+        try:
+            await self.coordinator.async_set_climate_timer_settings(updated)
+        except Exception:
+            self._clear_optimistic()
+            raise

--- a/custom_components/polestar/number.py
+++ b/custom_components/polestar/number.py
@@ -63,7 +63,11 @@ NUMBERS: tuple[PolestarNumberDescription, ...] = (
         native_min_value=0,
         native_max_value=30,
         native_step=0.5,
-        value_fn=lambda c: c.climate_preferences.target_temperature,
+        value_fn=lambda c: (
+            c.data.climate.target_temperature_celsius
+            if c.data and c.data.climate and c.data.climate.target_temperature_celsius is not None
+            else c.climate_preferences.target_temperature
+        ),
         set_fn=lambda c, val: None,
         restore_state=True,
     ),

--- a/custom_components/polestar/select.py
+++ b/custom_components/polestar/select.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .coordinator import PolestarCoordinator
-from .entity import PolestarEntity
+from .entity import OptimisticStateMixin, PolestarEntity
 from polestar_api.models.charging import ChargeTargetLevelSettingType
 from polestar_api.models.climatization import HeatingIntensity
 from polestar_api.models.parking_climate_timer import (
@@ -151,7 +151,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class PolestarSelect(PolestarEntity, RestoreEntity, SelectEntity):
+class PolestarSelect(OptimisticStateMixin, PolestarEntity, RestoreEntity, SelectEntity):
     """Select entity for local command preferences."""
 
     entity_description: PolestarSelectDescription
@@ -179,7 +179,8 @@ class PolestarSelect(PolestarEntity, RestoreEntity, SelectEntity):
         key = self.entity_description.key
         if key == "target_soc_setting_type":
             mode = self.coordinator.target_soc_setting_type
-            return mode.name.lower() if mode is not None else None
+            real_value = mode.name.lower() if mode is not None else None
+            return self._resolve_optimistic(real_value)
 
         prefs = self.coordinator.climate_preferences
         if key == "climate_front_left_seat":
@@ -196,8 +197,12 @@ class PolestarSelect(PolestarEntity, RestoreEntity, SelectEntity):
         key = self.entity_description.key
         if key == "target_soc_setting_type":
             # Explicit, deliberate mode switch — tells the car to change mode now.
-            await self.coordinator.async_set_target_soc_mode(_TARGET_SOC_MAP[option])
-            self.async_write_ha_state()
+            self._set_optimistic(option)
+            try:
+                await self.coordinator.async_set_target_soc_mode(_TARGET_SOC_MAP[option])
+            except Exception:
+                self._clear_optimistic()
+                raise
             return
 
         heating = _HEATING_MAP[option]
@@ -215,7 +220,7 @@ class PolestarSelect(PolestarEntity, RestoreEntity, SelectEntity):
         self.async_write_ha_state()
 
 
-class PolestarTimerSettingsSelect(PolestarEntity, SelectEntity):
+class PolestarTimerSettingsSelect(OptimisticStateMixin, PolestarEntity, SelectEntity):
     """Select entity for API-backed parking climate timer default settings."""
 
     entity_description: PolestarSelectDescription
@@ -243,20 +248,20 @@ class PolestarTimerSettingsSelect(PolestarEntity, SelectEntity):
         key = self.entity_description.key
         if key == "timer_battery_preconditioning":
             bp = settings.battery_preconditioning
-            if bp == BatteryPreconditioning.UNDEFINED:
-                return "off"
-            return bp.name.lower()
-        # Heating keys
-        if key == "timer_steering_wheel":
-            return settings.steering_wheel_heating.name.lower()
-        seat = settings.seat_heating
-        if key == "timer_front_left_seat":
-            return seat.front_left.name.lower()
-        if key == "timer_front_right_seat":
-            return seat.front_right.name.lower()
-        if key == "timer_rear_left_seat":
-            return seat.rear_left.name.lower()
-        return seat.rear_right.name.lower()
+            real_value = "off" if bp == BatteryPreconditioning.UNDEFINED else bp.name.lower()
+        elif key == "timer_steering_wheel":
+            real_value = settings.steering_wheel_heating.name.lower()
+        else:
+            seat = settings.seat_heating
+            if key == "timer_front_left_seat":
+                real_value = seat.front_left.name.lower()
+            elif key == "timer_front_right_seat":
+                real_value = seat.front_right.name.lower()
+            elif key == "timer_rear_left_seat":
+                real_value = seat.rear_left.name.lower()
+            else:
+                real_value = seat.rear_right.name.lower()
+        return self._resolve_optimistic(real_value)
 
     async def async_select_option(self, option: str) -> None:
         settings = self._settings
@@ -279,4 +284,9 @@ class PolestarTimerSettingsSelect(PolestarEntity, SelectEntity):
             else:
                 seat = replace(seat, rear_right=heating)
             updated = replace(settings, seat_heating=seat)
-        await self.coordinator.async_set_climate_timer_settings(updated)
+        self._set_optimistic(option)
+        try:
+            await self.coordinator.async_set_climate_timer_settings(updated)
+        except Exception:
+            self._clear_optimistic()
+            raise

--- a/custom_components/polestar/sensor.py
+++ b/custom_components/polestar/sensor.py
@@ -260,7 +260,7 @@ SENSORS: tuple[PolestarSensorDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
-        value_fn=lambda d: (d.dashboard.dashboard_data.trip_meter_auto_km if d.dashboard and d.dashboard.dashboard_data else None) or (d.odometer.trip_meter_automatic_km if d.odometer and d.odometer.trip_meter_automatic_km else None),
+        value_fn=lambda d: (d.dashboard.dashboard_data.trip_meter_auto_km if d.dashboard and d.dashboard.dashboard_data else None) or (d.odometer.trip_meter_automatic_km if d.odometer and d.odometer.trip_meter_automatic_km is not None else None),
     ),
     PolestarSensorDescription(
         key="heading",
@@ -328,8 +328,8 @@ SENSORS: tuple[PolestarSensorDescription, ...] = (
         name="Washer fluid warning",
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
-        options=enum_options(WasherFluidLevelWarning),
-        value_fn=lambda d: enum_name(d.health.washer_fluid_level_warning) if d.health else None,
+        options=enum_options(WasherFluidLevelWarning, exclude_unspecified=False),
+        value_fn=lambda d: enum_name(d.health.washer_fluid_level_warning, allow_unspecified=True) if d.health else None,
     ),
     PolestarSensorDescription(
         key="low_voltage_battery_warning",

--- a/custom_components/polestar/sensor.py
+++ b/custom_components/polestar/sensor.py
@@ -42,6 +42,7 @@ from polestar_api.models.climate import (
     ClimatizationRunningStatus,
     HeatOrCoolAction,
 )
+from polestar_api.models.climatization import HeatingIntensity
 from polestar_api.models.health import (
     BrakeFluidLevelWarning,
     LowVoltageBatteryWarning,
@@ -62,6 +63,14 @@ def _safe(fn: Callable[[PolestarVehicleData], Any], data: PolestarVehicleData) -
         return fn(data)
     except (AttributeError, TypeError, ValueError):
         return None
+
+
+def _heating_intensity_name(value: HeatingIntensity | None) -> str | None:
+    if value is None:
+        return None
+    if value in (HeatingIntensity.UNSPECIFIED, HeatingIntensity.OFF):
+        return "off"
+    return value.name.lower()
 
 
 def _current_charge_location_state(data: PolestarVehicleData) -> str | None:
@@ -453,6 +462,62 @@ SENSORS: tuple[PolestarSensorDescription, ...] = (
         native_unit_of_measurement=UnitOfTime.MINUTES,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda d: d.climate.time_remaining if d.climate else None,
+    ),
+    PolestarSensorDescription(
+        key="climate_current_temperature",
+        name="Climate current temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda d: d.climate.current_temperature_celsius if d.climate else None,
+    ),
+    PolestarSensorDescription(
+        key="climate_target_temperature",
+        name="Climate target temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda d: d.climate.target_temperature_celsius if d.climate else None,
+    ),
+    PolestarSensorDescription(
+        key="climate_front_left_seat",
+        name="Climate front left seat",
+        device_class=SensorDeviceClass.ENUM,
+        options=["off", "level1", "level2", "level3"],
+        icon="mdi:car-seat-heater",
+        value_fn=lambda d: _heating_intensity_name(d.climate.front_left_seat) if d.climate else None,
+    ),
+    PolestarSensorDescription(
+        key="climate_front_right_seat",
+        name="Climate front right seat",
+        device_class=SensorDeviceClass.ENUM,
+        options=["off", "level1", "level2", "level3"],
+        icon="mdi:car-seat-heater",
+        value_fn=lambda d: _heating_intensity_name(d.climate.front_right_seat) if d.climate else None,
+    ),
+    PolestarSensorDescription(
+        key="climate_rear_left_seat",
+        name="Climate rear left seat",
+        device_class=SensorDeviceClass.ENUM,
+        options=["off", "level1", "level2", "level3"],
+        icon="mdi:car-seat-heater",
+        value_fn=lambda d: _heating_intensity_name(d.climate.rear_left_seat) if d.climate else None,
+    ),
+    PolestarSensorDescription(
+        key="climate_rear_right_seat",
+        name="Climate rear right seat",
+        device_class=SensorDeviceClass.ENUM,
+        options=["off", "level1", "level2", "level3"],
+        icon="mdi:car-seat-heater",
+        value_fn=lambda d: _heating_intensity_name(d.climate.rear_right_seat) if d.climate else None,
+    ),
+    PolestarSensorDescription(
+        key="climate_steering_wheel",
+        name="Climate steering wheel",
+        device_class=SensorDeviceClass.ENUM,
+        options=["off", "level1", "level2", "level3"],
+        icon="mdi:steering",
+        value_fn=lambda d: _heating_intensity_name(d.climate.steering_wheel) if d.climate else None,
     ),
     PolestarSensorDescription(
         key="availability_unavailable_reason",

--- a/custom_components/polestar/switch.py
+++ b/custom_components/polestar/switch.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import PolestarCoordinator, PolestarVehicleData
-from .entity import PolestarEntity
+from .entity import OptimisticStateMixin, PolestarEntity
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -24,6 +24,7 @@ class PolestarSwitchDescription(SwitchEntityDescription):
     is_on_fn: Callable[[PolestarVehicleData], bool | None]
     turn_on_fn: Callable[[PolestarCoordinator], Awaitable[Any]]
     turn_off_fn: Callable[[PolestarCoordinator], Awaitable[Any]]
+    capability: str | None = None
 
 
 SWITCHES: tuple[PolestarSwitchDescription, ...] = (
@@ -34,6 +35,7 @@ SWITCHES: tuple[PolestarSwitchDescription, ...] = (
         is_on_fn=lambda d: d.climate.is_active if d.climate else None,
         turn_on_fn=lambda c: c.async_start_climate(),
         turn_off_fn=lambda c: c.async_stop_climate(),
+        capability="climate",
     ),
     PolestarSwitchDescription(
         key="precleaning",
@@ -42,6 +44,7 @@ SWITCHES: tuple[PolestarSwitchDescription, ...] = (
         is_on_fn=lambda d: d.precleaning.is_running if d.precleaning else None,
         turn_on_fn=lambda c: c.async_start_precleaning(),
         turn_off_fn=lambda c: c.async_stop_precleaning(),
+        capability="precleaning",
     ),
     PolestarSwitchDescription(
         key="charging",
@@ -50,6 +53,7 @@ SWITCHES: tuple[PolestarSwitchDescription, ...] = (
         is_on_fn=lambda d: d.battery.is_charging if d.battery else None,
         turn_on_fn=lambda c: c.async_start_charging(),
         turn_off_fn=lambda c: c.async_stop_charging(),
+        capability="charging",
     ),
     PolestarSwitchDescription(
         key="charge_timer",
@@ -59,6 +63,7 @@ SWITCHES: tuple[PolestarSwitchDescription, ...] = (
         is_on_fn=lambda d: d.charge_timer.timer.activated if d.charge_timer and d.charge_timer.timer else None,
         turn_on_fn=lambda c: c.async_set_charge_timer(activated=True),
         turn_off_fn=lambda c: c.async_set_charge_timer(activated=False),
+        capability="charge_timer",
     ),
 )
 
@@ -77,7 +82,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class PolestarSwitch(PolestarEntity, SwitchEntity):
+class PolestarSwitch(OptimisticStateMixin, PolestarEntity, SwitchEntity):
     """Polestar switch entity."""
 
     entity_description: PolestarSwitchDescription
@@ -88,16 +93,35 @@ class PolestarSwitch(PolestarEntity, SwitchEntity):
         self._attr_unique_id = f"{self._vehicle.vin}_{description.key}"
 
     @property
+    def available(self) -> bool:
+        """Return False if the car doesn't support this command."""
+        cap = self.entity_description.capability
+        if cap and not self.coordinator.is_command_supported(cap):
+            return False
+        return super().available
+
+    @property
     def is_on(self) -> bool | None:
         if self.coordinator.data is None:
             return None
         try:
-            return self.entity_description.is_on_fn(self.coordinator.data)
+            real_value = self.entity_description.is_on_fn(self.coordinator.data)
         except (AttributeError, TypeError):
             return None
+        return self._resolve_optimistic(real_value)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        await self.entity_description.turn_on_fn(self.coordinator)
+        self._set_optimistic(True)
+        try:
+            await self.entity_description.turn_on_fn(self.coordinator)
+        except Exception:
+            self._clear_optimistic()
+            raise
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        await self.entity_description.turn_off_fn(self.coordinator)
+        self._set_optimistic(False)
+        try:
+            await self.entity_description.turn_off_fn(self.coordinator)
+        except Exception:
+            self._clear_optimistic()
+            raise

--- a/custom_components/polestar/time.py
+++ b/custom_components/polestar/time.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import PolestarCoordinator
-from .entity import PolestarEntity
+from .entity import OptimisticStateMixin, PolestarEntity
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -55,7 +55,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class PolestarChargeTimerTime(PolestarEntity, TimeEntity):
+class PolestarChargeTimerTime(OptimisticStateMixin, PolestarEntity, TimeEntity):
     """Time entity for charge timer start/stop configuration."""
 
     entity_description: PolestarTimeDescription
@@ -82,8 +82,13 @@ class PolestarChargeTimerTime(PolestarEntity, TimeEntity):
         daily = getattr(timer, self.entity_description.value_attr)
         if daily is None:
             return None
-        return dt_time(hour=daily.hour, minute=daily.minute)
+        return self._resolve_optimistic(dt_time(hour=daily.hour, minute=daily.minute))
 
     async def async_set_value(self, value: dt_time) -> None:
         kwargs = {"start": value} if self.entity_description.value_attr == "start" else {"stop": value}
-        await self.coordinator.async_set_charge_timer(**kwargs)
+        self._set_optimistic(value)
+        try:
+            await self.coordinator.async_set_charge_timer(**kwargs)
+        except Exception:
+            self._clear_optimistic()
+            raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ Issues = "https://github.com/kildahldev/unofficial-polestar-api/issues"
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
+    "python-dotenv>=1.0",
+    "certifi>=2024.0",
 ]
 docs = [
     "mkdocs>=1.6",
@@ -46,3 +48,6 @@ packages = ["src/polestar_api"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = [
+    "live: marks tests that connect to live Polestar APIs (deselect with '-m \"not live\"')",
+]

--- a/src/polestar_api/connection.py
+++ b/src/polestar_api/connection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ssl
 from typing import TYPE_CHECKING
 
+import grpclib.client
 import grpclib.metadata
 from grpclib.client import Channel
 from grpclib.config import Configuration
@@ -16,7 +17,10 @@ if TYPE_CHECKING:
     from .auth import AuthManager
 
 # The C3 server rejects non-Java gRPC user agents with UNIMPLEMENTED.
+# grpclib.client imports USER_AGENT by value at module load, so we must
+# patch both the metadata module and the client module's binding.
 grpclib.metadata.USER_AGENT = "grpc-java-okhttp/1.68.2"
+grpclib.client.USER_AGENT = "grpc-java-okhttp/1.68.2"
 
 # Create SSL context at import time to avoid blocking the event loop.
 _SSL_CONTEXT = ssl.create_default_context()

--- a/src/polestar_api/models/climate.py
+++ b/src/polestar_api/models/climate.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from enum import IntEnum
 
 from ..wire import ProtoMessage
+from ..models.climatization import HeatingIntensity
 
 
 class ClimatizationRunningStatus(IntEnum):
@@ -52,6 +53,13 @@ class ClimatizationInfo(ProtoMessage, schema={
     request_type: ClimatizationRequestType = ClimatizationRequestType.UNDEFINED
     time_remaining: int = 0
     heat_or_cool_action: HeatOrCoolAction = HeatOrCoolAction.UNDEFINED
+    current_temperature_celsius: float | None = None
+    target_temperature_celsius: float | None = None
+    front_left_seat: HeatingIntensity | None = None
+    front_right_seat: HeatingIntensity | None = None
+    rear_left_seat: HeatingIntensity | None = None
+    rear_right_seat: HeatingIntensity | None = None
+    steering_wheel: HeatingIntensity | None = None
 
     @property
     def is_active(self) -> bool:

--- a/src/polestar_api/services/climate.py
+++ b/src/polestar_api/services/climate.py
@@ -13,6 +13,7 @@ from ..models.climate import (
     ClimatizationRunningStatus,
     HeatOrCoolAction,
 )
+from ..models.climatization import HeatingIntensity
 from ..models.common import VehicleRequest
 
 if TYPE_CHECKING:
@@ -52,6 +53,15 @@ class ClimateServiceClient:
         return mapping.get(value, ClimatizationRequestType.UNDEFINED)
 
     @staticmethod
+    def _map_seat_heating(value: int | None) -> HeatingIntensity | None:
+        if value is None:
+            return None
+        try:
+            return HeatingIntensity(value)
+        except ValueError:
+            return None
+
+    @staticmethod
     def _infer_heat_or_cool_action(raw: dict) -> HeatOrCoolAction:
         if raw.get(6):
             return HeatOrCoolAction.VENTILATION_ONLY
@@ -69,11 +79,20 @@ class ClimateServiceClient:
     @classmethod
     def _parse_digital_twin(cls, climate_bytes: bytes) -> ClimatizationInfo:
         raw = decode(climate_bytes)
+        current_temp = raw.get(7)
+        target_temp = raw.get(8)
         return ClimatizationInfo(
             running_status=cls._map_running_status(raw.get(2)),
             request_type=cls._map_request_type(raw.get(15)),
             time_remaining=int(raw.get(3, 0) or 0),
             heat_or_cool_action=cls._infer_heat_or_cool_action(raw),
+            current_temperature_celsius=float(current_temp) if isinstance(current_temp, (int, float)) else None,
+            target_temperature_celsius=float(target_temp) if isinstance(target_temp, (int, float)) else None,
+            front_left_seat=cls._map_seat_heating(raw.get(9)),
+            front_right_seat=cls._map_seat_heating(raw.get(10)),
+            rear_right_seat=cls._map_seat_heating(raw.get(11)),
+            rear_left_seat=cls._map_seat_heating(raw.get(12)),
+            steering_wheel=cls._map_seat_heating(raw.get(13)),
         )
 
     @classmethod

--- a/src/polestar_api/services/invocation.py
+++ b/src/polestar_api/services/invocation.py
@@ -50,17 +50,14 @@ class InvocationServiceClient:
     async def _call(self, method: str, request_bytes: bytes) -> bytes:
         metadata = await self._connection.get_metadata(self._vin)
         metadata["vin"] = self._vin
-        response = None
         async for response in grpc_call.unary_stream(
             self._connection.channel,
             f"{self._svc}/{method}",
             request_bytes,
             metadata=metadata,
         ):
-            pass
-        if response is None:
-            raise ApiError(f"{method} returned no invocation response")
-        return response
+            return response
+        raise ApiError(f"{method} returned no invocation response")
 
     async def lock(
         self,

--- a/tests/test_live_integration.py
+++ b/tests/test_live_integration.py
@@ -1,0 +1,546 @@
+"""Live integration tests for Polestar API.
+
+These tests connect to the real Polestar APIs using credentials from
+environment variables or a `.env` file. They are skipped if credentials
+are not provided.
+
+Usage:
+    # Create a .env file first (see .env.example):
+    #   POLESTAR_EMAIL=your_email@example.com
+    #   POLESTAR_PASSWORD=your_password
+    
+    # Run live tests (automatically loads .env)
+    pytest tests/test_live_integration.py -v -m live
+
+    # Or override with environment variables
+    POLESTAR_EMAIL=... POLESTAR_PASSWORD=... pytest tests/test_live_integration.py -v -m live
+
+    # Run specific test
+    pytest tests/test_live_integration.py::TestLiveBattery::test_get_battery -v
+"""
+
+import os
+import ssl
+from pathlib import Path
+
+import certifi
+import pytest
+
+try:
+    from dotenv import load_dotenv
+    HAS_DOTENV = True
+except ImportError:
+    HAS_DOTENV = False
+
+from polestar_api import PolestarApi
+from polestar_api.exceptions import AuthError
+from polestar_api.models.climate import ClimatizationRunningStatus
+
+
+# Load .env file before any tests run
+if HAS_DOTENV:
+    _env_path = Path(__file__).parent.parent / ".env"
+    if _env_path.exists():
+        load_dotenv(_env_path)
+
+
+@pytest.fixture(autouse=True)
+def configure_ssl():
+    """Fix SSL CA certificate verification on macOS Python 3.14+.
+
+    Python 3.14 on macOS doesn't find system CA certificates, causing
+    SSL verification to fail. Load certifi's CA bundle into the pre-built
+    SSL contexts in auth.py, discovery.py, and connection.py (all created
+    at import time before this fixture runs).
+
+    Uses separate contexts for HTTP/1.1 (httpx) and HTTP/2 (grpclib)
+    because httpx overwrites the ALPN setting on its context.
+    """
+    http_ctx = ssl.create_default_context(cafile=certifi.where())
+    grpc_ctx = ssl.create_default_context(cafile=certifi.where())
+    grpc_ctx.set_alpn_protocols(["h2"])
+
+    from polestar_api import auth, connection, discovery
+    auth._HTTPX_SSL_CONTEXT = http_ctx
+    discovery._SSL_CONTEXT = http_ctx
+    connection._SSL_CONTEXT = grpc_ctx
+
+
+@pytest.fixture
+def has_live_credentials():
+    """Check if live test credentials are available."""
+    email = os.environ.get("POLESTAR_EMAIL")
+    password = os.environ.get("POLESTAR_PASSWORD")
+    return bool(email and password)
+
+
+@pytest.fixture
+def live_credentials():
+    """Get live credentials from environment."""
+    email = os.environ.get("POLESTAR_EMAIL")
+    password = os.environ.get("POLESTAR_PASSWORD")
+    if not email or not password:
+        pytest.skip("POLESTAR_EMAIL and POLESTAR_PASSWORD environment variables required")
+    return email, password
+
+
+@pytest.fixture
+async def api_client(live_credentials):
+    """Create an authenticated API client."""
+    email, password = live_credentials
+    api = PolestarApi(email=email, password=password)
+    await api.async_init()
+    yield api
+    await api.close()
+
+
+@pytest.fixture
+async def vehicle(api_client):
+    """Get the first vehicle from the account."""
+    vehicles = await api_client.get_vehicles()
+    if not vehicles:
+        pytest.skip("No vehicles found on account")
+    return vehicles[0]
+
+
+class TestLiveAuth:
+    """Test authentication with real credentials."""
+
+    @pytest.mark.live
+    def test_credentials_provided(self, has_live_credentials):
+        """Verify credentials are available (or skip test)."""
+        if not has_live_credentials:
+            pytest.skip("Set POLESTAR_EMAIL and POLESTAR_PASSWORD to run live tests")
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_auth_succeeds(self, live_credentials):
+        """Test that authentication works with provided credentials."""
+        email, password = live_credentials
+        api = PolestarApi(email=email, password=password)
+        try:
+            await api.async_init()
+            assert api._auth.access_token is not None
+            assert len(api._auth.access_token) > 0
+        finally:
+            await api.close()
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_auth_invalid_credentials(self):
+        """Test that invalid credentials raise AuthError."""
+        api = PolestarApi(email="invalid@example.com", password="wrongpassword")
+        with pytest.raises(AuthError):
+            await api.async_init()
+        await api.close()
+
+
+class TestLiveVehicleDiscovery:
+    """Test vehicle discovery with real account."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_vehicles(self, api_client):
+        """Test fetching vehicle list."""
+        vehicles = await api_client.get_vehicles()
+        assert isinstance(vehicles, list)
+        assert len(vehicles) > 0
+        for v in vehicles:
+            print(f"  Vehicle: {v.model_name} ({v.model_year}) VIN={v.vin}")
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_vehicle_has_vin(self, vehicle):
+        """Test that vehicle has valid VIN."""
+        assert vehicle.vin is not None
+        assert len(vehicle.vin) == 17
+        print(f"  VIN: {vehicle.vin}")
+
+
+class TestLiveBattery:
+    """Test battery API endpoints."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_battery(self, vehicle):
+        """Test getting battery status."""
+        battery = await vehicle.get_battery()
+        if battery is not None:
+            assert 0 <= battery.charge_level <= 100
+            assert battery.range_km >= 0
+            print(f"  Battery: {battery.charge_level}% charge, {battery.range_km:.1f} km range")
+            print(f"  Status: {battery.charging_status.name}, plugged={battery.is_plugged_in}")
+            if battery.is_charging:
+                print(f"  Charging: {battery.power_watts}W, {battery.voltage_volts}V")
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_battery_properties(self, vehicle):
+        """Test battery status properties."""
+        battery = await vehicle.get_battery()
+        if battery is not None:
+            assert isinstance(battery.is_charging, bool)
+            assert isinstance(battery.is_plugged_in, bool)
+            print(f"  is_charging={battery.is_charging}, is_plugged_in={battery.is_plugged_in}")
+
+
+class TestLiveLocation:
+    """Test location API endpoints."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_location(self, vehicle):
+        """Test getting last known location."""
+        location = await vehicle.get_location()
+        if location is not None and location.coordinate is not None:
+            assert -90 <= location.coordinate.latitude <= 90
+            assert -180 <= location.coordinate.longitude <= 180
+            print(f"  Location: {location.coordinate.latitude:.6f}, {location.coordinate.longitude:.6f}")
+            print(f"  Altitude: {location.altitude}m, Heading: {location.heading}°, Speed: {location.speed}")
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_parked_location(self, vehicle):
+        """Test getting parked location."""
+        parked = await vehicle.get_parked_location()
+        if parked is not None and parked.coordinate is not None:
+            assert -90 <= parked.coordinate.latitude <= 90
+            assert -180 <= parked.coordinate.longitude <= 180
+            print(f"  Parked: {parked.coordinate.latitude:.6f}, {parked.coordinate.longitude:.6f}")
+
+
+class TestLiveExterior:
+    """Test exterior status endpoints."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_exterior(self, vehicle):
+        """Test getting exterior status."""
+        exterior = await vehicle.get_exterior()
+        if exterior is not None:
+            assert isinstance(exterior.is_locked, bool)
+            assert isinstance(exterior.any_door_open, bool)
+            print(f"  Locked: {exterior.is_locked}, any_door_open: {exterior.any_door_open}")
+            if exterior.doors:
+                print(f"  Doors: {exterior.doors}")
+            if exterior.windows:
+                print(f"  Windows: {exterior.windows}")
+
+
+class TestLiveClimate:
+    """Test climate API endpoints."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_climate(self, vehicle):
+        """Test getting climate status."""
+        climate = await vehicle.get_climate()
+        if climate is not None:
+            assert isinstance(climate.is_active, bool)
+            assert isinstance(climate.running_status, ClimatizationRunningStatus)
+            print(f"  Running: {climate.running_status.name}, active: {climate.is_active}")
+            print(f"  Request type: {climate.request_type.name}")
+            print(f"  Time remaining: {climate.time_remaining}s")
+            print(f"  Action: {climate.heat_or_cool_action.name}")
+            if climate.current_temperature_celsius is not None:
+                print(f"  Current temp: {climate.current_temperature_celsius}°C")
+            if climate.target_temperature_celsius is not None:
+                print(f"  Target temp: {climate.target_temperature_celsius}°C")
+
+
+class TestLiveOdometer:
+    """Test odometer API endpoints."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_odometer(self, vehicle):
+        """Test getting odometer reading."""
+        odometer = await vehicle.get_odometer()
+        if odometer is not None:
+            assert odometer.odometer_km >= 0
+            print(f"  Odometer: {odometer.odometer_km:.1f} km")
+            print(f"  Trip manual: {odometer.trip_meter_manual_km:.1f} km")
+            print(f"  Trip automatic: {odometer.trip_meter_automatic_km:.1f} km")
+
+
+class TestLiveHealth:
+    """Test health API endpoints."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_health(self, vehicle):
+        """Test getting health status."""
+        health = await vehicle.get_health()
+        if health is not None:
+            print(f"  Health: {health}")
+
+
+class TestLiveAvailability:
+    """Test availability API endpoints."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_availability(self, vehicle):
+        """Test getting availability status."""
+        availability = await vehicle.get_availability()
+        if availability is not None:
+            assert isinstance(availability.is_available, bool)
+            print(f"  Available: {availability.is_available}")
+            if hasattr(availability, "unavailable_reason"):
+                print(f"  Reason: {availability.unavailable_reason}")
+
+
+class TestLiveWeather:
+    """Test weather API endpoints."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_weather(self, vehicle):
+        """Test getting weather report."""
+        weather = await vehicle.get_weather()
+        if weather is not None:
+            assert weather.temperature_celsius is not None
+            print(f"  Weather: {weather}")
+
+
+class TestLiveCharging:
+    """Test charging API endpoints."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_target_soc(self, vehicle):
+        """Test getting target SOC."""
+        target_soc = await vehicle.get_target_soc()
+        assert 0 <= target_soc.target_level <= 100
+        print(f"  Target SOC: {target_soc.target_level}%")
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_amp_limit(self, vehicle):
+        """Test getting amp limit. Not supported on Polestar 4."""
+        from grpclib.exceptions import GRPCError
+        from grpclib.const import Status
+        try:
+            amp_limit = await vehicle.get_amp_limit()
+            assert amp_limit.amp_limit >= 0
+            print(f"  Amp limit: {amp_limit.amp_limit}A")
+        except GRPCError as e:
+            assert e.status == Status.UNIMPLEMENTED
+            print(f"  Amp limit: UNIMPLEMENTED ({e.message})")
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_charge_timer(self, vehicle):
+        """Test getting charge timer."""
+        charge_timer = await vehicle.get_charge_timer()
+        assert charge_timer is not None
+        print(f"  Charge timer: {charge_timer}")
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_charge_locations(self, vehicle):
+        """Test getting charge locations."""
+        locations = await vehicle.get_charge_locations()
+        assert isinstance(locations, list)
+        print(f"  Charge locations: {len(locations)} saved")
+        for loc in locations:
+            print(f"    - {loc}")
+
+
+class TestLivePreCleaning:
+    """Test pre-cleaning API endpoints."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_precleaning(self, vehicle):
+        """Test getting pre-cleaning status."""
+        precleaning = await vehicle.get_precleaning()
+        if precleaning is not None:
+            assert isinstance(precleaning.is_running, bool)
+            print(f"  Pre-cleaning: running={precleaning.is_running}")
+            print(f"  Details: {precleaning}")
+        else:
+            print(f"  Pre-cleaning: unavailable (None)")
+
+
+class TestLiveOTA:
+    """Test OTA API endpoints."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_software_info(self, vehicle):
+        """Test getting software info."""
+        ota_info = await vehicle.get_software_info()
+        if ota_info is not None:
+            print(f"  Software: {ota_info}")
+        else:
+            print(f"  Software: unavailable (None)")
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_ota_schedule(self, vehicle):
+        """Test getting OTA schedule."""
+        schedule = await vehicle.get_ota_schedule()
+        if schedule is not None:
+            print(f"  Schedule: {schedule}")
+        else:
+            print(f"  Schedule: unavailable (None)")
+
+
+class TestLiveDashboard:
+    """Test dashboard API endpoints (legacy PCCS)."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_dashboard(self, vehicle):
+        """Test getting dashboard status. UNIMPLEMENTED on Digital Twin (P4)."""
+        from grpclib.exceptions import GRPCError
+        from grpclib.const import Status
+        try:
+            dashboard = await vehicle.get_dashboard()
+            print(f"  Dashboard: {dashboard}")
+        except GRPCError as e:
+            assert e.status == Status.UNIMPLEMENTED
+            print(f"  Dashboard: UNIMPLEMENTED ({e.message})")
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_connectivity(self, vehicle):
+        """Test getting connectivity status. UNIMPLEMENTED on Digital Twin (P4)."""
+        from grpclib.exceptions import GRPCError
+        from grpclib.const import Status
+        try:
+            connectivity = await vehicle.get_connectivity()
+            print(f"  Connectivity: {connectivity}")
+        except GRPCError as e:
+            assert e.status == Status.UNIMPLEMENTED
+            print(f"  Connectivity: UNIMPLEMENTED ({e.message})")
+
+
+class TestLiveParkingClimateTimers:
+    """Test parking climate timer API endpoints."""
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_climate_timers(self, vehicle):
+        """Test getting climate timers."""
+        timers = await vehicle.get_climate_timers()
+        assert isinstance(timers, list)
+        print(f"  Climate timers: {len(timers)} scheduled")
+        for timer in timers:
+            print(f"    - {timer}")
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_get_climate_timer_settings(self, vehicle):
+        """Test getting climate timer settings. UNIMPLEMENTED on some vehicles."""
+        from grpclib.exceptions import GRPCError
+        from grpclib.const import Status
+        try:
+            settings = await vehicle.get_climate_timer_settings()
+            assert settings is not None
+            print(f"  Timer settings: {settings}")
+        except GRPCError as e:
+            assert e.status == Status.UNIMPLEMENTED
+            print(f"  Timer settings: UNIMPLEMENTED ({e.message})")
+
+
+# ============ WRITE COMMAND TESTS (Opt-in via environment variable) ============
+
+
+class TestLiveWriteCommands:
+    """Test write commands - DANGEROUS, disabled by default.
+
+    Set POLESTAR_ENABLE_WRITE_TESTS=1 to enable these tests.
+    Each test prompts for confirmation before execution.
+    """
+
+    @pytest.fixture
+    def write_commands_enabled(self):
+        """Check if write tests are enabled."""
+        return os.environ.get("POLESTAR_ENABLE_WRITE_TESTS") == "1"
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_lock(self, vehicle, write_commands_enabled):
+        """Test locking the car."""
+        if not write_commands_enabled:
+            pytest.skip("Set POLESTAR_ENABLE_WRITE_TESTS=1 to enable write tests")
+
+        confirm = input("\n⚠️  Lock the car? (y/N): ").strip().lower()
+        if confirm != 'y':
+            pytest.skip("User declined")
+
+        result = await vehicle.lock()
+        assert result is not None
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_unlock(self, vehicle, write_commands_enabled):
+        """Test unlocking the car."""
+        if not write_commands_enabled:
+            pytest.skip("Set POLESTAR_ENABLE_WRITE_TESTS=1 to enable write tests")
+
+        confirm = input("\n⚠️  Unlock the car? (y/N): ").strip().lower()
+        if confirm != 'y':
+            pytest.skip("User declined")
+
+        result = await vehicle.unlock()
+        assert result is not None
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_start_climate(self, vehicle, write_commands_enabled):
+        """Test starting climatization."""
+        if not write_commands_enabled:
+            pytest.skip("Set POLESTAR_ENABLE_WRITE_TESTS=1 to enable write tests")
+
+        confirm = input("\n⚠️  Start climate? (y/N): ").strip().lower()
+        if confirm != 'y':
+            pytest.skip("User declined")
+
+        result = await vehicle.start_climate()
+        assert result is not None
+        if result and result.response:
+            print(f"  Start climate: {result.response.status.name}")
+            assert result.response.status.name in ("SENT", "DELIVERED", "SUCCESS")
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_start_climate_with_temp(self, vehicle, write_commands_enabled):
+        """Test starting climatization with a target temperature."""
+        if not write_commands_enabled:
+            pytest.skip("Set POLESTAR_ENABLE_WRITE_TESTS=1 to enable write tests")
+
+        temp_input = input("\n🌡️  Start climate with target temperature (°C), or Enter for 22.0: ").strip()
+        try:
+            temp = float(temp_input) if temp_input else 22.0
+        except ValueError:
+            temp = 22.0
+        print(f"  Starting climate at {temp}°C...")
+        result = await vehicle.start_climate(temperature=temp)
+        assert result is not None
+        if result and result.response:
+            print(f"  Start climate {temp}°C: {result.response.status.name}")
+            assert result.response.status.name in ("SENT", "DELIVERED", "SUCCESS")
+
+        # Verify climate status reflects the change
+        climate = await vehicle.get_climate()
+        if climate is not None:
+            print(f"  Climate status: running={climate.running_status.name}, active={climate.is_active}")
+
+    @pytest.mark.live
+    @pytest.mark.asyncio
+    async def test_stop_climate(self, vehicle, write_commands_enabled):
+        """Test stopping climatization."""
+        if not write_commands_enabled:
+            pytest.skip("Set POLESTAR_ENABLE_WRITE_TESTS=1 to enable write tests")
+
+        confirm = input("\n⚠️  Stop climate? (y/N): ").strip().lower()
+        if confirm != 'y':
+            pytest.skip("User declined")
+
+        result = await vehicle.stop_climate()
+        assert result is not None
+        if result and result.response:
+            print(f"  Stop climate: {result.response.status.name}")

--- a/uv.lock
+++ b/uv.lock
@@ -681,6 +681,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -773,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "unofficial-polestar-api"
-version = "0.1.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpclib" },
@@ -782,8 +791,10 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "certifi" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "python-dotenv" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -793,6 +804,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "certifi", marker = "extra == 'dev'", specifier = ">=2024.0" },
     { name = "grpclib", specifier = ">=0.4.7" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6" },
@@ -800,6 +812,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.30" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0" },
 ]
 provides-extras = ["dev", "docs"]
 


### PR DESCRIPTION
## Summary

Three related pieces of work from my fork, squashed into a clean history on
top of `main` (0.3.0):

**Library fixes**
- `connection.py`: patch `grpclib.client.USER_AGENT` by value (it's imported
  by value, not by reference, so a plain module attribute reassignment
  wasn't taking effect) — the C3 backend rejects anything but the faked
  Android app user agent, and this was silently not applying.
- `invocation.py`: return the first stream response instead of waiting for
  the stream to close — the server keeps invocation streams open, so the
  old code would hang/timeout waiting for a close that never comes.
- Climate model + service: parse fields 7–13 from the Digital Twin response
  to expose current/target temperature and seat/steering heating intensity
  in `ClimatizationInfo`.

**HA integration**
- New sensors: climate current/target temperature and the four seat heating
  + steering wheel heating levels.
- `iot_class` corrected from `cloud_polling` to `cloud_push` (the
  integration already uses gRPC streaming for live updates).
- Coordinator now restarts dropped live streams after a successful poll
  proves connectivity, and tracks which streams the car doesn't support
  (`UNIMPLEMENTED`) so it stops retrying those specifically.
- Added `parked_location` to the live-streamed attributes.

**Instant optimistic UI updates**
Number/switch/select/time entities that issue a remote command (target SOC,
amp limit, climate temperature, charging/climate/pre-cleaning switches,
target SOC mode, charge timer start/stop, timer settings) previously waited
several seconds for the Polestar backend to confirm a change through a
coordinator refresh — and a premature confirmation poll could even revert
the UI back to the old value before the real one landed a few seconds later.

Each writable entity now uses a small `OptimisticStateMixin`: it shows the
new value immediately once the command succeeds, keeps showing it until the
coordinator reports a matching value (or a short timeout passes), and
reverts instantly if the command fails. This is scoped per-entity/per-field
rather than at the coordinator level, so it doesn't interfere with live
stream updates to unrelated fields.

Also added: per-command capability tracking for buttons/switches/lock (an
unsupported command marks the entity unavailable instead of failing
repeatedly), a live integration test suite (read-only by default, write
commands opt-in via env var — see `.env.example`), and a `CLAUDE.md` with
project conventions for anyone using Claude Code on this repo.

## Test plan

- `uv run pytest` — 64 passed (excludes the live-only suite, which needs
  real Polestar credentials)
- Manually verified in Home Assistant: target SOC slider, climate
  start/stop, and charging switch all reflect changes instantly and survive
  the background refresh without flickering back to the old value.

Happy to split this up or adjust anything if you'd prefer smaller PRs.