### PR TITLE
fix: bump spoofed Polestar app version to 5.11.0

### DIFF
--- a/src/polestar_api/discovery.py
+++ b/src/polestar_api/discovery.py
@@ -20,9 +20,9 @@ APP_BACKEND_GRAPHQL_URL = "https://pc-api.polestar.com/eu-north-1/app-backend/ap
 APP_BACKEND_ACCEPT_HEADER = "multipart/mixed;deferSpec=20220824, application/graphql-response+json, application/json"
 APP_BACKEND_OPERATION_NAME = "GetVDMSCars"
 APP_BACKEND_CLIENT_LIBRARY = {"name": "apollo-kotlin", "version": "4.4.1"}
-APP_FORCE_UPDATE_VERSION = "5.5.0"
+APP_FORCE_UPDATE_VERSION = "5.11.0"
 APP_LOCALE = "SE"
-APP_USER_AGENT = "PolestarApp/5.5.0b1102 Android/14"
+APP_USER_AGENT = "PolestarApp/5.11.0b1111 Android/14"
 
 APP_BACKEND_GET_VEHICLES_QUERY = """
 query GetVDMSCars {

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,92 @@
+import pytest
+
+from polestar_api.discovery import (
+    APP_BACKEND_GRAPHQL_URL,
+    APP_FORCE_UPDATE_VERSION,
+    APP_USER_AGENT,
+    _app_backend_headers,
+    get_vehicles,
+)
+from polestar_api.exceptions import ApiError
+
+
+class TestAppBackendHeaders:
+    def test_spoofs_current_official_android_app(self):
+        headers = _app_backend_headers("test-token")
+
+        assert APP_FORCE_UPDATE_VERSION == "5.11.0"
+        assert APP_USER_AGENT == "PolestarApp/5.11.0b1111 Android/14"
+        assert headers["User-Agent"] == APP_USER_AGENT
+        assert headers["X-Polestar-Force-Update-Version"] == APP_FORCE_UPDATE_VERSION
+        assert headers["X-PolestarId-Authorization"] == "Bearer test-token"
+
+
+class TestGetVehicles:
+    @pytest.mark.asyncio
+    async def test_sends_current_app_version_headers(
+        self, monkeypatch, mock_vehicles_response
+    ):
+        captured: dict[str, object] = {}
+
+        class FakeResponse:
+            status_code = 200
+
+            def json(self):
+                return mock_vehicles_response
+
+        class FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def post(self, url, headers=None, json=None):
+                captured["url"] = url
+                captured["headers"] = headers
+                captured["json"] = json
+                return FakeResponse()
+
+        monkeypatch.setattr("polestar_api.discovery.httpx.AsyncClient", FakeClient)
+
+        vehicles = await get_vehicles("test-token")
+
+        assert captured["url"] == APP_BACKEND_GRAPHQL_URL
+        headers = captured["headers"]
+        assert isinstance(headers, dict)
+        assert headers["User-Agent"] == "PolestarApp/5.11.0b1111 Android/14"
+        assert headers["X-Polestar-Force-Update-Version"] == "5.11.0"
+        assert headers["X-PolestarId-Authorization"] == "Bearer test-token"
+        assert len(vehicles) == 1
+        assert vehicles[0].vin == "YV4TEST000T0000001"
+
+    @pytest.mark.asyncio
+    async def test_upgrade_required_is_api_error(self, monkeypatch):
+        class FakeResponse:
+            status_code = 426
+            text = ""
+
+            def json(self):
+                raise ValueError("not json")
+
+        class FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def post(self, url, headers=None, json=None):
+                return FakeResponse()
+
+        monkeypatch.setattr("polestar_api.discovery.httpx.AsyncClient", FakeClient)
+
+        with pytest.raises(ApiError, match="426") as exc_info:
+            await get_vehicles("test-token")
+        assert exc_info.value.status_code == 426


### PR DESCRIPTION
## Summary
- Polestar's app-backend started returning **HTTP 426 (Upgrade Required)** for `GetVDMSCars` on 2026-08-18/19 when the client still claims Android app **5.5.0**.
- This matches [issue #25](https://github.com/kildahldev/unofficial-polestar-api/issues/25): auth succeeds, vehicle listing fails, and every HA entity goes unavailable.
- Bump `APP_FORCE_UPDATE_VERSION` / `APP_USER_AGENT` to the current official Android app **5.11.0 (build 1111)**, released 2026-08-18.
- Add `tests/test_discovery.py` so the GraphQL headers and the 426 `ApiError` path stay locked.

Please cut a patch release after merge so HACS users pick this up (the HA integration still pins `unofficial-polestar-api==0.3.0`).

## Test plan
- [x] `uv run pytest -q tests/test_discovery.py` (3 passed)
- [x] Reload / re-add the HA integration against a live Polestar ID and confirm vehicle list no longer 426s
- [x] Confirm existing config entries set up again after a Core restart

Fixes #25